### PR TITLE
change engine: CIO -> darwin + okhttp

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -58,6 +58,8 @@ kotlin {
             implementation(libs.voyager.transitions)
 
             implementation(libs.ktor.client.core)
+            implementation(libs.ktor.client.serialization)
+            implementation(libs.ktor.client.logging)
             implementation(libs.kotlinx.coroutines.core)
 
             implementation(libs.kvault)

--- a/composeApp/src/androidMain/kotlin/org/rocketserverkmm/project/EngineProviderAndroid.kt
+++ b/composeApp/src/androidMain/kotlin/org/rocketserverkmm/project/EngineProviderAndroid.kt
@@ -1,0 +1,15 @@
+package org.rocketserverkmm.project
+
+import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.engine.okhttp.OkHttp
+
+object EngineProviderAndroid : EngineProvider {
+    override fun createHttpClient(block: HttpClientConfig<*>.() -> Unit): HttpClient {
+        return HttpClient(OkHttp) {
+            block()
+        }
+    }
+}
+
+actual fun getEngine() : EngineProvider = EngineProviderAndroid

--- a/composeApp/src/commonMain/kotlin/org/rocketserverkmm/project/Engine.kt
+++ b/composeApp/src/commonMain/kotlin/org/rocketserverkmm/project/Engine.kt
@@ -1,0 +1,10 @@
+package org.rocketserverkmm.project
+
+import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
+
+interface EngineProvider {
+    fun createHttpClient(block: HttpClientConfig<*>.() -> Unit = {}): HttpClient
+}
+
+expect fun getEngine() : EngineProvider

--- a/composeApp/src/iosMain/kotlin/org/rocketserverkmm/project/EngineProviderIOS.kt
+++ b/composeApp/src/iosMain/kotlin/org/rocketserverkmm/project/EngineProviderIOS.kt
@@ -1,0 +1,15 @@
+package org.rocketserverkmm.project
+
+import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.engine.darwin.Darwin
+
+object EngineProviderIOS : EngineProvider {
+    override fun createHttpClient(block: HttpClientConfig<*>.() -> Unit): HttpClient {
+        return HttpClient(Darwin) {
+            block()
+        }
+    }
+}
+
+actual fun getEngine() : EngineProvider = EngineProviderIOS

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,6 +38,9 @@ androidx-lifecycle-runtime-compose = { group = "org.jetbrains.androidx.lifecycle
 apollo-runtime = { module = "com.apollographql.apollo:apollo-runtime", name = "apollo-runtime", version.ref = "apollo"}
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
+#ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
+ktor-client-serialization = { module = "io.ktor:ktor-client-serialization", version.ref = "ktor" }
+ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }


### PR DESCRIPTION
changed the engine because Apollo requests did not work on iOS due to the error `TLS sessions are not supported on Native platform`